### PR TITLE
remove file walking code from cert-viewer

### DIFF
--- a/main.go
+++ b/main.go
@@ -157,6 +157,9 @@ func run() error {
 		}
 	}
 
+	if len(certlist) == 0 {
+		return errors.New("No certificates found")
+	}
 	if err := certlist.verifyAllCerts(*disablesysroot); err != nil {
 		return errors.Wrap(err, "failed to verify")
 	}


### PR DESCRIPTION
We should not implement recursive file-walking inside cert-viewer but let the shell do it's job and make the argument to cert-viewer more specific.

**This PR introduces the following changes to implement this goal:**

- just parse all arguments and ignore directories given as arguments.
- it returns an error if no certificates are found (which is important for automation users)
- it does not enforce any file extensions anymore (which does not make sense on *nix systems anyway)

Removing filewalking has the added benefit to take away rough edges as the filewalking code tried a walk over all arguments given just to error out on the first ocassion of unparseable input.

To make the usage of cert-viewer more robust in automated environments (eg. with `--json`) this PR changed the behaviour so that if no certs could be found an error is returned. Where before if would just return successfully when an argument was given but no files where parsed (eg. if an empty directory was given) which could introduce a security problem in automated environments.

**Example of Usage new vs. old:**
new | old
------------ | -------------
`cert-viewer foo -> normal output` | `cert-viewer foo -> error wrong extension`
`cert-viewer dir/*` | `cert-viewer dir`
`cert-viewer emptydir/* -> error no certs found` | `cert-viewer emptydir -> success / no-output`